### PR TITLE
use cache directory for pretrained model

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ pip3 install kobert-transformers
 ```python
 >>> import torch
 >>> from kobert_transformers import get_kobert_model, get_distilkobert_model
->>> model = get_kobert_model()
+>>> model = get_kobert_model()  # if you want to use a cached pretrained model, use `get_kobert_model("./cache_dir")`
 >>> model.eval()
 >>> input_ids = torch.LongTensor([[31, 51, 99], [15, 5, 0]])
 >>> attention_mask = torch.LongTensor([[1, 1, 1], [1, 1, 0]])
@@ -131,7 +131,7 @@ tensor([[-0.2461,  0.2428,  0.2590,  ..., -0.4861, -0.0731,  0.0756],
 
 ```python
 >>> from kobert_transformers import get_tokenizer
->>> tokenizer = get_tokenizer()
+>>> tokenizer = get_tokenizer()  # if you want to use a cached tokenizer moddel, use `get_tokenizer("./cache_dir")`
 >>> tokenizer.tokenize("[CLS] 한국어 모델을 공유합니다. [SEP]")
 ['[CLS]', '▁한국', '어', '▁모델', '을', '▁공유', '합니다', '.', '[SEP]']
 >>> tokenizer.convert_tokens_to_ids(['[CLS]', '▁한국', '어', '▁모델', '을', '▁공유', '합니다', '.', '[SEP]'])

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Embedding(8002, 768, padding_idx=1)
 
 - `tokenization_kobert.py`를 랩핑한 파이썬 라이브러리
 - KoBERT, DistilKoBERT를 Huggingface Transformers 라이브러리 형태로 제공
-- `v0.4.0`에서는 `transformers v2.9.1` 이상으로 기본 설치합니다.
+- `v0.4.2`에서는 `transformers v2.9.1` 이상으로 기본 설치합니다.
 
 ### Install Kobert-Transformers
 

--- a/kobert_transformers/__init__.py
+++ b/kobert_transformers/__init__.py
@@ -1,4 +1,4 @@
 from .utils import get_tokenizer
 from .load_model import get_kobert_model, get_kobert_lm, get_distilkobert_model,  get_distilkobert_lm
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'

--- a/kobert_transformers/load_model.py
+++ b/kobert_transformers/load_model.py
@@ -1,25 +1,37 @@
 from transformers import BertModel, BertForMaskedLM, DistilBertModel, DistilBertForMaskedLM
 
 
-def get_kobert_model():
+def get_kobert_model(cache_dir=None):
     """ Return BertModel for Kobert """
-    model = BertModel.from_pretrained('monologg/kobert')
+    if cache_dir is not None:
+        model = BertModel.from_pretrained(cache_dir)
+    else:
+        model = BertModel.from_pretrained('monologg/kobert')
     return model
 
 
-def get_kobert_lm():
+def get_kobert_lm(cache_dir=None):
     """ Return BertForMaskedLM for Kobert """
-    model = BertForMaskedLM.from_pretrained('monologg/kobert-lm')
+    if cache_dir is not None:
+        model = BertModel.from_pretrained(cache_dir)
+    else:
+        model = BertForMaskedLM.from_pretrained('monologg/kobert-lm')
     return model
 
 
-def get_distilkobert_model():
+def get_distilkobert_model(cache_dir=None):
     """ Return DistilBertModel for DistilKobert """
-    model = DistilBertModel.from_pretrained('monologg/distilkobert')
+    if cache_dir is not None:
+        model = BertModel.from_pretrained(cache_dir)
+    else:
+        model = DistilBertModel.from_pretrained('monologg/distilkobert')
     return model
 
 
-def get_distilkobert_lm():
+def get_distilkobert_lm(cache_dir=None):
     """ Return DistilBertForMaskedLM for DistilKobert """
-    model = DistilBertForMaskedLM.from_pretrained('monologg/distilkobert')
+    if cache_dir is not None:
+        model = BertModel.from_pretrained(cache_dir)
+    else:
+        model = DistilBertForMaskedLM.from_pretrained('monologg/distilkobert')
     return model

--- a/kobert_transformers/utils.py
+++ b/kobert_transformers/utils.py
@@ -1,5 +1,8 @@
 from .tokenization_kobert import KoBertTokenizer
 
 
-def get_tokenizer():
-    return KoBertTokenizer.from_pretrained('monologg/kobert')
+def get_tokenizer(cache_dir=None):
+    if cache_dir is not None:
+        return KoBertTokenizer.from_pretrained(cache_dir)
+    else:
+        return KoBertTokenizer.from_pretrained('monologg/kobert')


### PR DESCRIPTION
[Issue #3](https://github.com/monologg/KoBERT-Transformers/issues/3#issue-805509785)

변경점
1.  model과 tokenizer를 load할 때 Cache 사용
- cache_dir을 인자로 넣어주면 해당 디렉토리에서 캐시된 모델을 Load
- 인자값을 넣어주지 않으면 transformers에서 model을 다운로드 받음
2. README
3. version