### PR TITLE
transformer 4.34.0 버전부터 tokenizer init 단계에서 vocab을 참조합니다. 

### DIFF
--- a/kobert_transformers/tokenization_kobert.py
+++ b/kobert_transformers/tokenization_kobert.py
@@ -82,14 +82,6 @@ class KoBertTokenizer(PreTrainedTokenizer):
         mask_token="[MASK]",
         **kwargs,
     ):
-        super().__init__(
-            unk_token=unk_token,
-            sep_token=sep_token,
-            pad_token=pad_token,
-            cls_token=cls_token,
-            mask_token=mask_token,
-            **kwargs,
-        )
 
         # Build vocab
         self.token2idx = dict()
@@ -116,6 +108,15 @@ class KoBertTokenizer(PreTrainedTokenizer):
 
         self.sp_model = spm.SentencePieceProcessor()
         self.sp_model.Load(vocab_file)
+
+        super().__init__(
+            unk_token=unk_token,
+            sep_token=sep_token,
+            pad_token=pad_token,
+            cls_token=cls_token,
+            mask_token=mask_token,
+            **kwargs,
+        )
 
     @property
     def vocab_size(self):


### PR DESCRIPTION
KoBertTokenizer init에서 Build vocab 단계를 마친 이후에 super()를 호출해야합니다.

기존 코드로 실행 시 tokenizer 생성 단계에서 아래 에러가 발생합니다.
`AttributeError: 'KoBertTokenizer' object has no attribute 'token2idx'`

